### PR TITLE
Appropriately set z-index

### DIFF
--- a/src/content/index.jsx
+++ b/src/content/index.jsx
@@ -13,11 +13,15 @@ import CommonTheme from './themes/common';
 
 let theme = CommonTheme;
 
+// The widget should live on the right-hand side of the screen, with a width of 250px, and be 20px from the right-edge of screen
+// Need z-index so widget doesn't get blocked on Indeed.com
+const WIDGET_CONTAINER_STYLES = 'z-index: 1000; position: fixed; left: calc(100% - 270px); top: 75px; padding-right: 20px; min-width: 270px;';
+
 const app = document.createElement('div');
 app.id = APP_ELEMENT_ID;
+
 if (window.location.host === 'www.linkedin.com') {
-  // The widget should live on the right-hand side of the screen, with a width of 250px, and be 20px from the right-edge of screen
-  app.setAttribute('style', 'position: fixed; left: calc(100% - 270px); top: 75px; padding-right: 20px; min-width: 270px;');
+  app.setAttribute('style', WIDGET_CONTAINER_STYLES);
 
   if (document.getElementsByClassName('nav-main__content').length) {
     document.getElementsByClassName('nav-main__content')[0].appendChild(app);
@@ -26,8 +30,7 @@ if (window.location.host === 'www.linkedin.com') {
   }
 } else if (window.location.host === 'www.indeed.com') {
   theme = IndeedTheme;
-  // The widget should live on the right-hand side of the screen, with a width of 250px, and be 20px from the right-edge of screen
-  app.setAttribute('style', 'position: fixed; left: calc(100% - 270px); top: 75px; padding-right: 20px; min-width: 270px;');
+  app.setAttribute('style', WIDGET_CONTAINER_STYLES);
 
   if (document.getElementById('gnav-main-container')) {
     document.getElementById('gnav-main-container').appendChild(app);


### PR DESCRIPTION
Indeed.com will block widget if containing `div` does not have a `z-index` value.

So set a `z-index` value for container such that it renders above any Indeed.com content and such that it does not block the tooltip's text (i.e. the container has a lower `z-index` than the tooltips).